### PR TITLE
30 disable powerplans by default in submitorders

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.5.1-alpha.0",
+  "version": "0.6.0-alpha.0",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/functional/submitOrders.spec.ts
+++ b/src/functional/submitOrders.spec.ts
@@ -32,17 +32,17 @@ describe('submitOrders', () => {
     const pidAndEidAtHead = eventString.startsWith('1|2');
     expect(pidAndEidAtHead).toBe(true);
   });
-  test('setting `disablePowerPlans` to `false` updates the `eventString` properly', () => {
+  test('setting `enablePowerPlans` to `true` updates the `eventString` properly', () => {
     const opts: SubmitOrderOpts = {
-      disablePowerPlans: false,
+      enablePowerPlans: true,
     };
     const { eventString } = submitOrders(1, 2, [order], opts);
     const expectedString = '1|2|{ORDER|0|0|0|0|0}|24|{2|127}|32|0';
     expect(eventString).toBe(expectedString);
   });
-  test('setting `disablePowerPlans` to `true` updates the `eventString` properly', () => {
+  test('setting `enablePowerPlans` to `false` updates the `eventString` properly', () => {
     const opts: SubmitOrderOpts = {
-      disablePowerPlans: true,
+      enablePowerPlans: false,
     };
     const { eventString } = submitOrders(1, 2, [order], opts);
     const expectedString = '1|2|{ORDER|0|0|0|0|0}|0|{2|127}|32|0';
@@ -53,7 +53,7 @@ describe('submitOrders', () => {
       targetTab: 'orders',
     };
     const { eventString } = submitOrders(1, 2, [order], opts);
-    const expectedString = '1|2|{ORDER|0|0|0|0|0}|24|{2|0}|32|0';
+    const expectedString = '1|2|{ORDER|0|0|0|0|0}|0|{2|0}|32|0';
     expect(eventString).toBe(expectedString);
   });
   test('setting `targetTab` to `power orders` updates the `eventString` properly', () => {
@@ -61,7 +61,7 @@ describe('submitOrders', () => {
       targetTab: 'power orders',
     };
     const { eventString } = submitOrders(1, 2, [order], opts);
-    const expectedString = '1|2|{ORDER|0|0|0|0|0}|24|{2|127}|32|0';
+    const expectedString = '1|2|{ORDER|0|0|0|0|0}|0|{2|127}|32|0';
     expect(eventString).toBe(expectedString);
   });
   test('setting the `targetTab` to `medications` updates the `eventString` properly', () => {
@@ -69,7 +69,7 @@ describe('submitOrders', () => {
       targetTab: 'medications',
     };
     const { eventString } = submitOrders(1, 2, [order], opts);
-    const expectedString = '1|2|{ORDER|0|0|0|0|0}|24|{3|0}|32|0';
+    const expectedString = '1|2|{ORDER|0|0|0|0|0}|0|{3|0}|32|0';
     expect(eventString).toBe(expectedString);
   });
   test('setting the `targetTab` to `power medications` updates the `eventString` properly', () => {
@@ -77,7 +77,7 @@ describe('submitOrders', () => {
       targetTab: 'power medications',
     };
     const { eventString } = submitOrders(1, 2, [order], opts);
-    const expectedString = '1|2|{ORDER|0|0|0|0|0}|24|{3|127}|32|0';
+    const expectedString = '1|2|{ORDER|0|0|0|0|0}|0|{3|127}|32|0';
     expect(eventString).toBe(expectedString);
   });
   test('setting the `launchView` to `search` updates the `eventString` properly', () => {
@@ -85,7 +85,7 @@ describe('submitOrders', () => {
       launchView: 'search',
     };
     const { eventString } = submitOrders(1, 2, [order], opts);
-    const expectedString = '1|2|{ORDER|0|0|0|0|0}|24|{2|127}|8|0';
+    const expectedString = '1|2|{ORDER|0|0|0|0|0}|0|{2|127}|8|0';
     expect(eventString).toBe(expectedString);
   });
   test('setting the `launchView` to `profile` updates the `eventString` properly', () => {
@@ -93,7 +93,7 @@ describe('submitOrders', () => {
       launchView: 'profile',
     };
     const { eventString } = submitOrders(1, 2, [order], opts);
-    const expectedString = '1|2|{ORDER|0|0|0|0|0}|24|{2|127}|16|0';
+    const expectedString = '1|2|{ORDER|0|0|0|0|0}|0|{2|127}|16|0';
     expect(eventString).toBe(expectedString);
   });
   test('setting the `launchView` to `signature` updates the `eventString` properly', () => {
@@ -101,7 +101,7 @@ describe('submitOrders', () => {
       launchView: 'signature',
     };
     const { eventString } = submitOrders(1, 2, [order], opts);
-    const expectedString = '1|2|{ORDER|0|0|0|0|0}|24|{2|127}|32|0';
+    const expectedString = '1|2|{ORDER|0|0|0|0|0}|0|{2|127}|32|0';
     expect(eventString).toBe(expectedString);
   });
   test('setting `signSilently` to `false` updates the `eventString` properly', () => {
@@ -109,7 +109,7 @@ describe('submitOrders', () => {
       signSilently: false,
     };
     const { eventString } = submitOrders(1, 2, [order], opts);
-    const expectedString = '1|2|{ORDER|0|0|0|0|0}|24|{2|127}|32|0';
+    const expectedString = '1|2|{ORDER|0|0|0|0|0}|0|{2|127}|32|0';
     expect(eventString).toBe(expectedString);
   });
   test('setting `signSilently` to `true` updates the `eventString` properly', () => {
@@ -117,19 +117,19 @@ describe('submitOrders', () => {
       signSilently: true,
     };
     const { eventString } = submitOrders(1, 2, [order], opts);
-    const expectedString = '1|2|{ORDER|0|0|0|0|0}|24|{2|127}|32|1';
+    const expectedString = '1|2|{ORDER|0|0|0|0|0}|0|{2|127}|32|1';
     expect(eventString).toBe(expectedString);
   });
   test('not providing options properly produces default `eventString` values', () => {
     const { eventString } = submitOrders(1, 2, [order]);
-    const expectedString = '1|2|{ORDER|0|0|0|0|0}|24|{2|127}|32|0';
+    const expectedString = '1|2|{ORDER|0|0|0|0|0}|0|{2|127}|32|0';
     expect(eventString).toBe(expectedString);
   });
-  test('setting `targetTab` to `power medications`, `launchView` to `signature`, `disablePowerPlans` to `true`, and `signSilently` to `true` produces the proper `eventString`', () => {
+  test('setting `targetTab` to `power medications`, `launchView` to `signature`, `enablePowerPlans` to `false`, and `signSilently` to `true` produces the proper `eventString`', () => {
     const opts: SubmitOrderOpts = {
       targetTab: 'power medications',
       launchView: 'signature',
-      disablePowerPlans: true,
+      enablePowerPlans: false,
       signSilently: true,
     };
     const { eventString } = submitOrders(1, 2, [order], opts);

--- a/src/functional/submitOrders.ts
+++ b/src/functional/submitOrders.ts
@@ -34,8 +34,8 @@ export type SubmitOrderOpts = {
 
 /**
  * Submit orders for a patient in a given encounter through the Cerner PowerChart MPage Event interface.
- * By default, power plans are enabled, the target tab is set to order with power orders enabled, and
- * will launch to the signature view.
+ * By default, power plans are disabled (potential bug in PowerChart), the target tab is set to order
+ * with power orders enabled, and will launch to the signature view.
  * @param {number} personId - The identifier for the patient to whom the note belongs.
  * Cerner context variable: PAT_PersonId.
  * @param {number} encounterId - The identifier for the encounter belonging to the patient where

--- a/src/functional/submitOrders.ts
+++ b/src/functional/submitOrders.ts
@@ -17,7 +17,10 @@ const tabsMap = new Map<string, { tab: number; display: number }>()
  * If not provided, will default to `power orders`, that is the orders tab with power orders enabled.
  * @action `launchView` - (optional) Sets the view to be displayed.If not provided,
  * will default to `search` view.
- * @action `disablePowerPlans` - (optional) Disables power plans. Power plans are enabled by default.
+ * @action `enablePowerPlans` - (optional) Enables power plans in the MOEW. Power plans are disabled by default.
+ * **NOTE**: Our internal testing suggests there is a _PowerChart_ bug relating to enabling this option
+ * where making MPAGES_EVENT calls, through `submitOrders`, in series with this option enabled will lead
+ * to some MPAGES_EVENT calls failing to be invoked. Please keep this in mind when enabling this option.
  * @action `silentSign` - (optional) Signs the orders silently. Orders are not signed silently by default.
  *
  * @documentation [MPAGES_EVENT - ORDER](https://wiki.cerner.com/display/public/MPDEVWIKI/MPAGES_EVENT+-+ORDERS)
@@ -25,7 +28,7 @@ const tabsMap = new Map<string, { tab: number; display: number }>()
 export type SubmitOrderOpts = {
   targetTab?: 'orders' | 'power orders' | 'medications' | 'power medications';
   launchView?: 'search' | 'profile' | 'signature';
-  disablePowerPlans?: boolean;
+  enablePowerPlans?: boolean;
   signSilently?: boolean;
 };
 
@@ -51,7 +54,7 @@ export const submitOrders = (
   orders: Array<string>,
   opts?: SubmitOrderOpts
 ): { eventString: string; inPowerChart: boolean } => {
-  let { targetTab, launchView, disablePowerPlans, signSilently } = opts || {};
+  let { targetTab, launchView, enablePowerPlans, signSilently } = opts || {};
   if (!targetTab) targetTab = 'power orders';
   if (!launchView) launchView = 'signature';
 
@@ -63,7 +66,7 @@ export const submitOrders = (
     orders.join(''),
   ];
 
-  params.push(disablePowerPlans ? '0' : '24');
+  params.push(enablePowerPlans ? '24' : '0');
 
   const { tab, display } = tabsMap.get(targetTab) || { tab: 2, display: 127 };
   params.push(`{${tab}|${display}}`);


### PR DESCRIPTION
- Updated documentation to reflect changes in the API 
- Updated documentation to note a probably bug in PowerChart where MPAGES_EVENT calls (in this case through `submitOrder`) made in series may not all execute when power plans are enabled.
- `disablePowerPlans` is now `enablePowerPlans`
- `enablePowerPlans` default to `undefined` and effectively functions as false (disabled)