### PR TITLE
Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,193 +1,161 @@
 # fluent-cerner-js
 
-A fluent `MPAGE_EVENT` string generation library.
+A modern API for interacting with the Cerner Millennium application. Modern Typescript/Javascript wrappers have been created to enhance the productivity of software engineers who are tasked with interacting with the Cerner Millennium application. This software is in it's alpha stage and should be used with caution. Additionally, it doesn't cover a full set of the Cerner Millennium application's functionality. It is a work in progress.
 
 | Environment | CI                                                                                                                             | Publish                                                                                                   |
 | ----------- | ------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------- |
 | Production  | ![Main Build](https://github.com/geekmdtravis/fluent-cerner-js/actions/workflows/main.yml/badge.svg?branch=main)               | ![Main Publish](https://github.com/geekmdtravis/fluent-cerner-js/actions/workflows/publish.yml/badge.svg) |
 | Development | ![Development Build](https://github.com/geekmdtravis/fluent-cerner-js/actions/workflows/main.yml/badge.svg?branch=development) | Not Applicable                                                                                            |
 
-## Resources
+## Contributors
 
-- [MPage Developer Guide - MPAGE_EVENT Orders](https://wiki.cerner.com/display/public/MPDEVWIKI/MPAGES_EVENT-ORDERS)
+- [Travis Nesbit, MD (geekmdtravis)](https://github.com/geekmdtravis/) - Primary Author
+- [Daniel "Danny" Lara, MD (dl2github)](https://github.com/dl2github)
 
-### Anatomy of an `MPAGE_EVENT` String for the `ORDER` type.
+## API In Action
 
-An `MPAGE_EVENT` string takes the form:
-
-```
-personId|encounterId|orderList|customizeFlags|tabList|defaultDisplay|silentSignFlag
-```
-
-Where `orderList` is a series of braces-contained, pipe-delimited strings that takes the form:
-
-```
-{orderAction|orderId|synonymId|orderOrigination|orderSentenceId|nomenclatureId|signTimeInteractionFlag}
-```
-
-Where `tabList` is a single brace-contained, pip-delimited string that takes the form:
-
-```
-{tab|tabDisplayFlags}
-```
-
-### Definitions
-
-- `personId`: The `person_id` of the patient whose Modal Order Entry Window (MOEW) is to be displayed.
-- `encounterId`: The `encntr_id` of the patient whose MOEW is to be displayed.
-- `orderList`: The list of order actions and properties that define the data that is to be loaded into the MOEW.
-  - A set that must be enclosed by curly brackets `{` and `}`.
-  - If you want only to launch into the MOEW and not to add any new orders or perform any other order actions, an empty orderAction / orderProperties set of `{ORDER|0|0|0|0|0}` can be used.
-- `orderAction`: The type of action to be performed on an order.
-  - Must follow the `{"ORDER"|synonymId|orderOrigination|orderSentenceId|nomenclatureId|signTimeInteractionFlag}` signature.
-    - `"ORDER"` The prototype for placing a new order.
-  - Must follow the `{<ORDER_ACTION_TYPE>|orderId}` signature.
-    - `"ACTIVATE"` - The prototype for activating an existing future order.
-    - `"CANCEL DC"` The prototype for canceling / discontinuing an existing order.
-    - `"CANCEL REORD"` The prototype for canceling and reordering an existing order.
-    - `"CLEAR"` The prototype for clearing the future actions of an existing order.
-    - `"CONVERT_INPAT"` The prototype for converting a historical or prescription order into an inpatient order.
-    - `"CONVERT_RX"` The prototype for converting an existing non-prescription order to a prescription order.
-    - `"MODIFY"` The prototype for modifying an existing order.
-    - `"RENEW"` The prototype for renewing an existing non-prescription order.
-    - `"RENEW_RX"` The prototype for renewing an existing prescription order.
-    - `"REPEAT"` The prototype for copying an existing order.
-    - `"RESUME"` The prototype for resuming an existing suspended order.
-    - `"SUSPEND"` The prototype for suspending an existing order.
-  - Child Paramters:
-    - `orderId`: The `order_id` associated with an existing order.
-    - `synonymId`: The `synonym_id` to be associated with the new order.
-    - `orderOrigination`: The type of order to be associated with the new order. A value of represents a normal order.
-      - `1`: Prescription order.
-      - `5`: satellite order
-    - `orderSenteceId`: The optional `order_sentence_id` to be associated with the new order.
-    - `nomenclatureId`: The optional `nomenclature_id` to be associated with the new order.
-    - `signTimeInterationFlag`: A Boolean flag to determine if interaction checking should only be performed at sign-time or not.
-- `customizeFlags`: A set of flags that can be used to define the style of the MOEW.
-  - `0`: default, no PowerPlans.
-  - `24`: enable PowerPlans.
-- `tabList`: The customization data for the different tab(s) of the MOEW.
-  - A set that must be enclosed by the `{` and `}` braces.
-  - Parameters within the sets are pipe-delimited.
-  - Child Parameters
-    - `tab`: The tab that is to be modified.
-      - `2`: customizations to the Order List profile.
-      - `3`: customizations to the Medication List profile.
-    - `tabDisplayFlags`: A set of flags that can be used to define the style of the tab being altered by 'tab'.
-      - `127` For full PowerOrders functionality.
-- `defaultDisplay`: The view to display by default when launching into the MOEW.
-  - `8`: default to the order search.
-  - `16`: default to the order profile.
-  - `32`: default to the orders for signature.
-- `silentSignFlag` (optional): A Boolean flag used to determine if the MOEW should sign orders silently. When this flag is set, and the required details on each new order are pre-populated, it causes the orders to be signed automatically without displaying the MOEW. Orders are signed automatically when existing orders are not already on the scratchpad and no other orderActions are present.
-
-### Example
-
-One would read the following:
-
-```
-6204|3623|{REPEAT|123456}{REPEAT|654321}{REPEAT|987654}|24|{2|127}|16
-```
-
-As:
-
-- For patient `6204`,
-- In encounter `3623`,
-- We will copy the following list orders by their `orderId`:
-  - 123456
-  - 654321
-  - 987654
-- With **PowerPlans** enabled,
-- Customizing the **Order List Profile** with **PowerOrder** functionality
-- Defaulting to the **Order Profile** view.
-
-## API In Action: Create and Send Orders to MOEW
+### Create and Send Orders to MOEW
 
 ```js
-/************************************************
- * Create and submit new orders to PowerChart
- ************************************************/
+const o1 = orderString('copy existing', { orderId: 12345 });
 
-// Functional ulities
-// ------------------
-
-const orderStr1 = orderString('copy existing', { orderId: 12345 });
-
-const orderStr2 = orderString('new order', {
+const o2 = orderString('new order', {
   newOrderOpts: {
     synonymId: 1343,
     origination: 'prescription',
   },
 });
 
-const orderStr3 = orderString('new order', {
+const o3 = orderString('new order', {
   newOrderOpts: {
     synonymId: 3428,
     orderSentenceId: 3,
-    nomenclatureId: 14,
+    nomenclatureIds: [14, 15],
     interactionCheck: 'on sign',
   },
 });
 
-submitOrders(123, 456, [orderStr1, orderStr2, orderStr3]);
+submitOrders(123, 456, [o1, o2, o3]);
+```
 
-// Class utilities
-// ---------------
+### Make a CCL Request from an MPage
 
-const order1 = new MPageOrder();
-order1.willCopyExistingOrder(12345);
+Using the provided tooling inside of PowerChart, making a CCL request is a complex endeavor. This library abstracts away the complexity and provides a simple interface for making CCL requests and provides an easy way to handle the response asynchronously. It returns a `Promise`.
 
-const order2 = new MPageOrder();
-order2.willMakeNewOrder(1343, { isRxOrder: true });
+#### Using `Promise` syntax
 
-const opts = {
-  orderSentenceId: 3,
-  nomenclatureId: 14,
-  skipInteractionCheckUntilSign: true,
-};
-const order3 = new MPageOrder();
-order3.willMakeNewOrder(3428, opts);
-
-const event = new MPageOrderEvent();
-event
-  .forPerson(123)
-  .forEncounter(456)
-  .addOrders([order1, order2, order3])
-  .enablePowerPlans()
-  .customizeOrderListProfile()
-  .enablePowerOrders()
-  .launchOrdersForSignature();
-
-// Send the MPage event to the server.
-event.send();
-
-/********************************************************
- * Make a CCL request to the server and retrieve the data
- ********************************************************/
-let result = undefined;
-makeCclRequest({
+```ts
+const opts: CclOpts = {
   prg: 'MP_GET_ORDER_LIST',
   params: [
     { type: 'number', param: 12345 },
     { type: 'string', param: 'joe' },
   ],
-})
-  .then(data => (result = data))
-  .catch(console.error)
-  .finally(() => console.log(result));
+};
+
+makeCclRequest(opts)
+  .then(data => setData(data))
+  .catch(err => console.error(err))
+  .finally(() => console.log("I'm done!"));
 ```
 
-## Other Functions Not Demonstrated Above
+#### Using `async/await`
 
-1. `launchClinicalNote`
-2. `launchPowerForm`
-3. `launchPowerNote`
-4. `openPatientTab`
-5. `openOrganizerTab`
+```ts
+const opts: CclOpts = {
+  prg: 'MP_GET_ORDER_LIST',
+  params: [
+    { type: 'number', param: 12345 },
+    { type: 'string', param: 'joe' },
+  ],
+};
+
+try {
+  const data = await makeCclRequest(opts);
+  setData(result);
+} catch (error) {
+  console.error(error);
+} finally {
+  console.log("I'm done!");
+}
+```
+
+### Launch a Clinical Note
+
+```ts
+const opts: ClinicalNoteOpts = {
+  personId: 8316243,
+  encounterId: 12575702,
+  eventIds: [155543],
+  windowTitle: 'Clinical Notes Title',
+  viewOptionFlags: ['view-only'],
+};
+
+launchClinicalNote(opts);
+```
+
+### Launch PowerForm
+
+```ts
+const opts: PowerFormOpts = {
+  personId: 733757,
+  encounterId: 701346,
+  target: 'completed form',
+  targetId: 15721144,
+  permissions: 'modify',
+};
+
+launchPowerForm(opts);
+```
+
+### Launch a PowerNote
+
+```ts
+const opts: PowerNoteOpts = {
+  personId: 123456,
+  encounterId: 78910,
+  target: 'existing',
+  targetId: 1337,
+};
+
+launchPowerNote(opts);
+```
+
+### Launch a Tab at the Organizer Level
+
+Open a tab at the organizer level (no patient context). Arguments provided are _tab name_.
+
+```ts
+openOrganizerTab('Tab Name');
+```
+
+### Launch a Tab at the Patient Level
+
+Open a tab at the patient level (patient context is present). Arguments provided are _person ID_, _encounter ID_, _tab name_, and optional _boolean_ for whether or not attempt to open a _Quick Add_ tab (not available in all tabs).
+
+```ts
+openPatientTab(12345, 51353, 'Tab Name', true);
+```
+
+### Verification and Context Validation
+
+Each function will return an object `{eventString: string, inPowerChart: boolean}`. This object can be used to verify the event string and context of the application. `eventString` does not give information about the function called, but does give a final representation of the string that is being fed into the relevant function and is therefore useful for debugging. If you're developing outside of PowerChart the error generated will be caught and logged to the console along with returning the object with the `inPowerChart` property set to `false`.
+
+```ts
+const { eventString, inPowerChart } = openPatientTab(0, 1, 'Tab Name', true);
+
+if (!inPowerChart) {
+  dispatch(
+    appWarning(
+      `You're not in PowerChart! The generated event string is ${eventString}`
+    )
+  );
+}
+```
 
 ## TypeScript Support
 
-This library was developedin typescript and all relevant types are exported.
+This library was developed with _TypeScript_ and all relevant types are exported.
 
 ```tsx
 import { makeCclRequest, CclCallParam, CclOpts } from 'fluent-cerner-js';
@@ -220,7 +188,140 @@ const MyComponent = ({ user }) => {
 };
 ```
 
-## Contributors
+---
 
-- [Travis Nesbit, MD (geekmdtravis)](https://github.com/geekmdtravis/) - Primary Author
-- [Daniel "Danny" Lara, MD(dl2github)](https://github.com/dl2github)
+## Resources
+
+- [MPage Developer Guide - MPAGE_EVENT Orders](https://wiki.cerner.com/display/public/MPDEVWIKI/MPAGES_EVENT-ORDERS)
+
+## Anatomy of an `MPAGE_EVENT` String for the `ORDER` type.
+
+### Background: Examples
+
+**Copying two orders:**
+
+```
+6204|3623|{REPEAT|123456}{REPEAT|654321}{REPEAT|987654}|24|{2|127}|16
+```
+
+Read the above string to say:
+
+- For patient `6204`,
+- In encounter `3623`,
+- We will copy the following list orders by their `orderId`:
+  - 123456
+  - 654321
+  - 987654
+- With **PowerPlans** enabled,
+- Customizing the **Order List Profile** with **PowerOrder** functionality
+- Defaulting to the **Order Profile** view.
+
+**Placing two new orders:**
+
+```
+"6204|3623|{ORDER|123456|0|0|[961514]|1}{ORDER|654321|0|0|[1029704|1029801|961514]|1}|24|{2|127}|16|1"
+```
+
+Read the above string to say:
+
+- For patient `6204`,
+- In encounter `3623`,
+- We will place new orders for the following list orders by their `orderId`:
+  - 123456
+    - Having a single `nomenclatureId` of `961514` (e.g. a single diagnosis)
+  - 654321
+    - Having multiple `nomenclatureId`'s of `1029704`, `1029801`, and `961514` (e.g multiple diagnoses)
+- With **PowerPlans** enabled,
+- Customizing the **Order List Profile** with **PowerOrder** functionality
+- Defaulting to the **Order Profile** view.
+- Placing orders **silently** (no confirmation dialog)
+
+When passed as the second argument to the `MPAGES_EVENT` function (first argument is the string `"ORDERS"`), this event string will instruct the Cerner Millennium application to silently place two orders, one with multiple `nomenclatureId`s and one with a single `nomenclatureId`, into the patient's order list.
+
+Example raw usage of the `MPAGES_EVENT` function with a manually constructed string:
+
+```html
+<a
+  href='javascript:MPAGES_EVENT("ORDERS","8316243|12575702|{ORDER|0|0|0|0|0}|0|{2|127}{3|127}|8")'
+  >Add a new order</a
+>
+```
+
+### Breakdown of the `MPAGE_EVENT` string for the `ORDER` type
+
+An `MPAGE_EVENT` string takes the form:
+
+```
+personId|encounterId|orderList|customizeFlags|tabList|defaultDisplay|silentSignFlag
+```
+
+Where `orderList` is a series of braces-contained, pipe-delimited strings that takes the form:
+
+```
+{orderAction|orderId|synonymId|orderOrigination|orderSentenceId|nomenclatureId|signTimeInteractionFlag}
+```
+
+or where there are multiple `nomenclatureId`'s, will take the form:
+
+```
+{orderAction|orderId|synonymId|orderOrigination|orderSentenceId|[nomenclatureId1|nomenclatureId2|...|nomenclatureIdN]|signTimeInteractionFlag}
+```
+
+Where `tabList` is a single brace-contained, pip-delimited string that takes the form:
+
+```
+{tab|tabDisplayFlags}
+```
+
+### Definitions of `MPAGES_EVENT` variables for the `ORDER` type
+
+- `personId`: The `person_id` of the patient whose Modal Order Entry Window (MOEW) is to be displayed.
+- `encounterId`: The `encntr_id` of the patient whose MOEW is to be displayed.
+- `orderList`: The list of order actions and properties that define the data that is to be loaded into the MOEW.
+  - A set that must be enclosed by curly brackets `{` and `}`.
+  - If you want only to launch into the MOEW and not to add any new orders or perform any other order actions, an empty orderAction / orderProperties set of `{ORDER|0|0|0|0|0}` can be used.
+- `orderAction`: The type of action to be performed on an order.
+  - Must follow the `{"ORDER"|synonymId|orderOrigination|orderSentenceId|nomenclatureId|signTimeInteractionFlag}` signature.
+    - `"ORDER"` The prototype for placing a new order.
+  - Must follow the `{<ORDER_ACTION_TYPE>|orderId}` signature.
+    - `"ACTIVATE"` - The prototype for activating an existing future order.
+    - `"CANCEL DC"` The prototype for canceling / discontinuing an existing order.
+    - `"CANCEL REORD"` The prototype for canceling and reordering an existing order.
+    - `"CLEAR"` The prototype for clearing the future actions of an existing order.
+    - `"CONVERT_INPAT"` The prototype for converting a historical or prescription order into an inpatient order.
+    - `"CONVERT_RX"` The prototype for converting an existing non-prescription order to a prescription order.
+    - `"MODIFY"` The prototype for modifying an existing order.
+    - `"RENEW"` The prototype for renewing an existing non-prescription order.
+    - `"RENEW_RX"` The prototype for renewing an existing prescription order.
+    - `"REPEAT"` The prototype for copying an existing order.
+    - `"RESUME"` The prototype for resuming an existing suspended order.
+    - `"SUSPEND"` The prototype for suspending an existing order.
+  - Child Paramters:
+    - `orderId`: The `order_id` associated with an existing order.
+    - `synonymId`: The `synonym_id` to be associated with the new order. This can be thought of the identifier for a given order. E.g. _atorvastatin_.
+    - `orderOrigination`: The type of order to be associated with the new order. A value of represents a normal order.
+      - `1`: Prescription order.
+      - `5`: satellite order
+    - `orderSenteceId`: The optional `order_sentence_id` to be associated with the new order. This can be thought of as the value that specifies which variant of an order is placed. E.g. for _atovastatin_ you will likely have multiple order sentences to support dosing variants like _10 mg once daily_ vs _5_ mg once daily\_.
+    - `nomenclatureId`: The optional `nomenclature_id` to be associated with the new order. This is generally a value that will be linked to an ICD code or SNOMED code. Thus the need to support multiple `nomenclatureId`'s for any given order.
+    - `signTimeInterationFlag`: A Boolean flag to determine if interaction checking should only be performed at sign-time or not.
+- `customizeFlags`: A set of flags that can be used to define the style of the MOEW.
+  - `0`: no PowerPlans.
+  - `24`: enable PowerPlans.
+- `tabList`: The customization data for the different tab(s) of the MOEW.
+  - A set that must be enclosed by the `{` and `}` braces.
+  - Parameters within the sets are pipe-delimited.
+  - Child Parameters
+    - `tab`: The tab that is to be modified.
+      - `2`: customizations to the Order List profile.
+      - `3`: customizations to the Medication List profile.
+    - `tabDisplayFlags`: A set of flags that can be used to define the style of the tab being altered by 'tab'.
+      - `0`: no PowerOrders functionality.
+      - `127` For full PowerOrders functionality.
+- `defaultDisplay`: The view to display by default when launching into the MOEW.
+  - `8`: default to the order search.
+  - `16`: default to the order profile.
+  - `32`: default to the orders for signature.
+- `silentSignFlag`: A Boolean flag used to determine if the MOEW should sign orders silently. When this flag is set, and the required details on each new order are pre-populated, it causes the orders to be signed automatically without displaying the MOEW. Orders are signed automatically when existing orders are not already on the scratchpad and no other orderActions are present.
+  - `0`: do not sign orders silently.
+  - `1`: sign orders silently.

--- a/demo.js
+++ b/demo.js
@@ -40,36 +40,6 @@ const orderStr3 = orderString('new order', {
 
 submitOrders(123, 456, [orderStr1, orderStr2, orderStr3]);
 
-// Class utilities
-// ---------------
-
-const order1 = new MPageOrder();
-order1.willCopyExistingOrder(12345);
-
-const order2 = new MPageOrder();
-order2.willMakeNewOrder(1343, { isRxOrder: true });
-
-const opts = {
-  orderSentenceId: 3,
-  nomenclatureIds: [14],
-  skipInteractionCheckUntilSign: true,
-};
-const order3 = new MPageOrder();
-order3.willMakeNewOrder(3428, opts);
-
-const event = new MPageOrderEvent();
-event
-  .forPerson(123)
-  .forEncounter(456)
-  .addOrders([order1, order2, order3])
-  .enablePowerPlans()
-  .customizeOrderListProfile()
-  .enablePowerOrders()
-  .launchOrdersForSignature();
-
-// Send the MPage event to the server.
-event.send();
-
 /********************************************************
  * Make a CCL request to the server and retrieve the data
  ********************************************************/

--- a/demo.js
+++ b/demo.js
@@ -33,7 +33,7 @@ const orderStr3 = orderString('new order', {
   newOrderOpts: {
     synonymId: 3428,
     orderSentenceId: 3,
-    nomenclatureId: 14,
+    nomenclatureIds: [14, 15, 16],
     interactionCheck: 'on sign',
   },
 });
@@ -51,7 +51,7 @@ order2.willMakeNewOrder(1343, { isRxOrder: true });
 
 const opts = {
   orderSentenceId: 3,
-  nomenclatureId: 14,
+  nomenclatureIds: [14],
   skipInteractionCheckUntilSign: true,
 };
 const order3 = new MPageOrder();
@@ -89,7 +89,7 @@ makeCclRequest({
  * Open a specific tab in a patients chart
  ********************************************************/
 
-openPatientTab(12345, 54321, 'Notes', true);
+openPatientTab(12345, 54321, 'Notes');
 
 /********************************************************
  * Open a specific organizer level tab

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.0-alpha.0",
+  "version": "0.7.0-alpha.0",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/functional/orderString.spec.ts
+++ b/src/functional/orderString.spec.ts
@@ -44,11 +44,17 @@ describe('makeOrderString', () => {
     });
     expect(result).toBe('{ORDER|1|0|2|0|0}');
   });
-  test("'new order' with a 'nomenclatureId' of `3` returns `{ORDER|1|0|0|3|0}`", () => {
+  test("'new order' with 'nomenclatureIds' of `3` returns `{ORDER|1|0|0|3|0}`", () => {
     const result = orderString('new order', {
-      newOrderOpts: { synonymId: 1, nomenclatureId: 3 },
+      newOrderOpts: { synonymId: 1, nomenclatureIds: [3] },
     });
     expect(result).toBe('{ORDER|1|0|0|3|0}');
+  });
+  test("'new order' with 'nomenclatureIds' of `3` and `4` returns `{ORDER|1|0|0|[3|4]|0}`", () => {
+    const result = orderString('new order', {
+      newOrderOpts: { synonymId: 1, nomenclatureIds: [3, 4] },
+    });
+    expect(result).toBe('{ORDER|1|0|0|[3|4]|0}');
   });
   test("'new order' with an `interaction` of `on sign` returns `{ORDER|1|0|0|0|1}`", () => {
     const result = orderString('new order', {
@@ -130,7 +136,7 @@ describe('makeOrderString', () => {
         synonymId: 1,
         origination: 'prescription',
         orderSentenceId: 2,
-        nomenclatureId: 3,
+        nomenclatureIds: [3],
         interactionCheck: 'on sign',
       },
     });

--- a/src/functional/orderString.ts
+++ b/src/functional/orderString.ts
@@ -37,7 +37,7 @@ export type OrderAction =
  * @param `synonymId` - The Cerner synonym_id for the order to be generated.
  * @param `orderSentenceId` - (optional) The order sentence id to be associated with the new order.
  * This is an accompanied value to the synonymId and provides specificity to the order type.
- * @param `nomenclatureId` - (optional) The nomenclature id, or associated problem/diagnosis, to be associated with the new order.
+ * @param `nomenclatureIds` - (optional) An array of nomenclature ids (identifiers for problems/diagnoses) to be associated with the new order.
  * @param `interaction` - (optional) Defines when an interaction between the provider and PowerChart takes place only at sign time, or impromptu.
  * @param `origination` - (optional) Defines the origination of the order as `satellite`, `prescription`, or `normal`.
  *
@@ -46,7 +46,7 @@ export type OrderAction =
 export type NewOrderStrOpts = {
   synonymId: number;
   orderSentenceId?: number;
-  nomenclatureId?: number;
+  nomenclatureIds?: Array<number>;
   interactionCheck?: 'on sign' | 'default';
   origination?: 'satellite' | 'prescription' | 'normal';
 };
@@ -80,12 +80,14 @@ export const orderString = (
   const {
     synonymId,
     orderSentenceId,
-    nomenclatureId,
+    nomenclatureIds,
     interactionCheck: interaction,
     origination,
   } = newOrderOpts || {};
 
   let params: Array<string> = [orderActionMap.get(action)];
+
+  const nids = nomenclatureIds || [];
 
   switch (action) {
     case 'launch moew':
@@ -98,7 +100,7 @@ export const orderString = (
         `${synonymId}`,
         `${originationMap.get(origination) || 0}`,
         `${orderSentenceId || 0}`,
-        `${nomenclatureId || 0}`,
+        nids.length > 1 ? `[${nids.join('|')}]` : `${nids[0] || 0}`,
         `${interactionMap.get(interaction) || 0}`,
       ]);
       break;

--- a/src/functional/submitOrders.spec.ts
+++ b/src/functional/submitOrders.spec.ts
@@ -32,23 +32,24 @@ describe('submitOrders', () => {
     const pidAndEidAtHead = eventString.startsWith('1|2');
     expect(pidAndEidAtHead).toBe(true);
   });
-  test('setting `enablePowerPlans` to `true` updates the `eventString` properly', () => {
+  test('setting `targetTab` to `power orders` updates the `eventString` to include the _PowerPlans_ flag `24` and _PowerOrders_ flag `127` and sets the target tab to `2`.', () => {
     const opts: SubmitOrderOpts = {
-      enablePowerPlans: true,
+      targetTab: 'power orders',
     };
     const { eventString } = submitOrders(1, 2, [order], opts);
     const expectedString = '1|2|{ORDER|0|0|0|0|0}|24|{2|127}|32|0';
     expect(eventString).toBe(expectedString);
   });
-  test('setting `enablePowerPlans` to `false` updates the `eventString` properly', () => {
+  test('setting `targetTab` to `power medications` updates the `eventString` to include the _PowerPlans_ flag `24` and _PowerOrders_ flag `127` and sets the target tab to `3`.', () => {
     const opts: SubmitOrderOpts = {
-      enablePowerPlans: false,
+      targetTab: 'power medications',
     };
     const { eventString } = submitOrders(1, 2, [order], opts);
-    const expectedString = '1|2|{ORDER|0|0|0|0|0}|0|{2|127}|32|0';
+    const expectedString = '1|2|{ORDER|0|0|0|0|0}|24|{3|127}|32|0';
     expect(eventString).toBe(expectedString);
   });
-  test('setting `targetTab` to `orders` updates the `eventString` properly', () => {
+
+  test('setting `targetTab` to `orders` updates the `eventString` properly to a target tab of `2` with both _PowerOrders_ and _PowerPlans_ disabled.', () => {
     const opts: SubmitOrderOpts = {
       targetTab: 'orders',
     };
@@ -56,15 +57,8 @@ describe('submitOrders', () => {
     const expectedString = '1|2|{ORDER|0|0|0|0|0}|0|{2|0}|32|0';
     expect(eventString).toBe(expectedString);
   });
-  test('setting `targetTab` to `power orders` updates the `eventString` properly', () => {
-    const opts: SubmitOrderOpts = {
-      targetTab: 'power orders',
-    };
-    const { eventString } = submitOrders(1, 2, [order], opts);
-    const expectedString = '1|2|{ORDER|0|0|0|0|0}|0|{2|127}|32|0';
-    expect(eventString).toBe(expectedString);
-  });
-  test('setting the `targetTab` to `medications` updates the `eventString` properly', () => {
+
+  test('setting `targetTab` to `medications` updates the `eventString` properly to a target tab of `3` with both _PowerOrders_ and _PowerPlans_ disabled.', () => {
     const opts: SubmitOrderOpts = {
       targetTab: 'medications',
     };
@@ -72,68 +66,60 @@ describe('submitOrders', () => {
     const expectedString = '1|2|{ORDER|0|0|0|0|0}|0|{3|0}|32|0';
     expect(eventString).toBe(expectedString);
   });
-  test('setting the `targetTab` to `power medications` updates the `eventString` properly', () => {
-    const opts: SubmitOrderOpts = {
-      targetTab: 'power medications',
-    };
-    const { eventString } = submitOrders(1, 2, [order], opts);
-    const expectedString = '1|2|{ORDER|0|0|0|0|0}|0|{3|127}|32|0';
-    expect(eventString).toBe(expectedString);
-  });
-  test('setting the `launchView` to `search` updates the `eventString` properly', () => {
+
+  test('setting the `launchView` to `search` updates the `eventString` to include the proper flag `8`', () => {
     const opts: SubmitOrderOpts = {
       launchView: 'search',
     };
     const { eventString } = submitOrders(1, 2, [order], opts);
-    const expectedString = '1|2|{ORDER|0|0|0|0|0}|0|{2|127}|8|0';
+    const expectedString = '1|2|{ORDER|0|0|0|0|0}|0|{2|0}|8|0';
     expect(eventString).toBe(expectedString);
   });
-  test('setting the `launchView` to `profile` updates the `eventString` properly', () => {
+  test('setting the `launchView` to `profile` updates the `eventString` properly to include the proper flag `16`', () => {
     const opts: SubmitOrderOpts = {
       launchView: 'profile',
     };
     const { eventString } = submitOrders(1, 2, [order], opts);
-    const expectedString = '1|2|{ORDER|0|0|0|0|0}|0|{2|127}|16|0';
+    const expectedString = '1|2|{ORDER|0|0|0|0|0}|0|{2|0}|16|0';
     expect(eventString).toBe(expectedString);
   });
-  test('setting the `launchView` to `signature` updates the `eventString` properly', () => {
+  test('setting the `launchView` to `signature` updates the `eventString` properly to include the proper flag `32`', () => {
     const opts: SubmitOrderOpts = {
       launchView: 'signature',
     };
     const { eventString } = submitOrders(1, 2, [order], opts);
-    const expectedString = '1|2|{ORDER|0|0|0|0|0}|0|{2|127}|32|0';
+    const expectedString = '1|2|{ORDER|0|0|0|0|0}|0|{2|0}|32|0';
     expect(eventString).toBe(expectedString);
   });
-  test('setting `signSilently` to `false` updates the `eventString` properly', () => {
+  test('setting `signSilently` to `false` updates the `eventString` properly to end the string with a `0` flag', () => {
     const opts: SubmitOrderOpts = {
       signSilently: false,
     };
     const { eventString } = submitOrders(1, 2, [order], opts);
-    const expectedString = '1|2|{ORDER|0|0|0|0|0}|0|{2|127}|32|0';
+    const expectedString = '1|2|{ORDER|0|0|0|0|0}|0|{2|0}|32|0';
     expect(eventString).toBe(expectedString);
   });
-  test('setting `signSilently` to `true` updates the `eventString` properly', () => {
+  test('setting `signSilently` to `true` updates the `eventString` properly to end the string with a `1` flag', () => {
     const opts: SubmitOrderOpts = {
       signSilently: true,
     };
     const { eventString } = submitOrders(1, 2, [order], opts);
-    const expectedString = '1|2|{ORDER|0|0|0|0|0}|0|{2|127}|32|1';
+    const expectedString = '1|2|{ORDER|0|0|0|0|0}|0|{2|0}|32|1';
     expect(eventString).toBe(expectedString);
   });
-  test('not providing options properly produces default `eventString` values', () => {
+  test('not providing options properly produces default `eventString` values with disabled _PowerPlans_, disabled _PowerOrders_, target tab of orders tab `2`, and showing orders for signature `32`', () => {
     const { eventString } = submitOrders(1, 2, [order]);
-    const expectedString = '1|2|{ORDER|0|0|0|0|0}|0|{2|127}|32|0';
+    const expectedString = '1|2|{ORDER|0|0|0|0|0}|0|{2|0}|32|0';
     expect(eventString).toBe(expectedString);
   });
-  test('setting `targetTab` to `power medications`, `launchView` to `signature`, `enablePowerPlans` to `false`, and `signSilently` to `true` produces the proper `eventString`', () => {
+  test('setting `targetTab` to `power medications`, `launchView` to `signature`, and `signSilently` to `true` produces the proper `eventString`', () => {
     const opts: SubmitOrderOpts = {
       targetTab: 'power medications',
       launchView: 'signature',
-      enablePowerPlans: false,
       signSilently: true,
     };
     const { eventString } = submitOrders(1, 2, [order], opts);
-    const expectedString = '1|2|{ORDER|0|0|0|0|0}|0|{3|127}|32|1';
+    const expectedString = '1|2|{ORDER|0|0|0|0|0}|24|{3|127}|32|1';
     expect(eventString).toBe(expectedString);
   });
 });

--- a/src/functional/submitOrders.ts
+++ b/src/functional/submitOrders.ts
@@ -14,35 +14,37 @@ const tabsMap = new Map<string, { tab: number; display: number }>()
 
 /**
  * @action `targetTab` - (optional) Sets the tab to be displayed, with and without power orders.
- * If not provided, will default to `power orders`, that is the orders tab with power orders enabled.
+ * If not provided, will default to `orders`, that is the orders tab with _PowerOrders_ disabled.
+ * Any tab with the term _power_ in it will enable both _PowerOrders_ and _PowerPlans_ in _PowerChart_.
  * @action `launchView` - (optional) Sets the view to be displayed.If not provided,
  * will default to `search` view.
- * @action `enablePowerPlans` - (optional) Enables power plans in the MOEW. Power plans are disabled by default.
- * **NOTE**: Our internal testing suggests there is a _PowerChart_ bug relating to enabling this option
- * where making MPAGES_EVENT calls, through `submitOrders`, in series with this option enabled will lead
- * to some MPAGES_EVENT calls failing to be invoked. Please keep this in mind when enabling this option.
  * @action `silentSign` - (optional) Signs the orders silently. Orders are not signed silently by default.
- *
  * @documentation [MPAGES_EVENT - ORDER](https://wiki.cerner.com/display/public/MPDEVWIKI/MPAGES_EVENT+-+ORDERS)
+ * @warning Our internal testing suggests there is a _PowerChart_ bug relating to the use of power
+ * orders. When making MPAGES_EVENT calls (which we do in this library through `submitOrders`)
+ * in series with power orders enabled, the result was that some MPAGES_EVENT calls failed to be invoked.
+ * Please keep this in mind when enabling this option. For our own use, we have disabled power orders when
+ * using `submitOrders` in such a way that calls are made in series.
  */
 export type SubmitOrderOpts = {
   targetTab?: 'orders' | 'power orders' | 'medications' | 'power medications';
   launchView?: 'search' | 'profile' | 'signature';
-  enablePowerPlans?: boolean;
   signSilently?: boolean;
 };
 
 /**
- * Submit orders for a patient in a given encounter through the Cerner PowerChart MPage Event interface.
- * By default, power plans are disabled (potential bug in PowerChart), the target tab is set to order
- * with power orders enabled, and will launch to the signature view.
+ * Submit orders for a patient in a given encounter through the _Cerner PowerChart_ `MPAGES_EVENT` function.
+ * By default, _PowerPlans_ are disabled (potential bug in _PowerChart_), _PowerOrders_ are disabled,
+ * the target tab is set to orders, and will launch to the signature view.
  * @param {number} personId - The identifier for the patient to whom the note belongs.
  * Cerner context variable: PAT_PersonId.
  * @param {number} encounterId - The identifier for the encounter belonging to the patient where
  * this note will be launched. Cerner context variable: VIS_EncntrId.
- * @param orders - The orders to be submitted. Orders are given in the form of an
- * Cerner MPage Order string of pipe-delimited parameters.
- * @param opts - (optional) User defined options for the order submission event.
+ * @param orders - The orders to be submitted. Orders are given in the form of a a series of pipe-delimited
+ * parameters as specified in the `MPAGES_EVENT` documentation (below). Use the `fluent-cerner-js` library's
+ * `orderString` function to simplify building these pipe-delimited order strings.
+ * @param opts - (optional) User defined options for the order submission event. The options allow for
+ * changing the target tab, the view to be launched, and whether or not the orders should be signed silently.
  * @returns an object with the order `eventString` and a boolean flag set to notify the user if
  * the attempt was made outside of PowerChart, `inPowerChart`.
  *
@@ -54,9 +56,11 @@ export const submitOrders = (
   orders: Array<string>,
   opts?: SubmitOrderOpts
 ): { eventString: string; inPowerChart: boolean } => {
-  let { targetTab, launchView, enablePowerPlans, signSilently } = opts || {};
-  if (!targetTab) targetTab = 'power orders';
+  let { targetTab, launchView, signSilently } = opts || {};
+  if (!targetTab) targetTab = 'orders';
   if (!launchView) launchView = 'signature';
+  const enablePowerPlans =
+    targetTab === 'power orders' || targetTab === 'power medications';
 
   let inPowerChart = true;
 


### PR DESCRIPTION
1. Now support multiple nomenclature id's for a given order. Breaking changes: (1) `nomenclatureId` property is not `nomenclatureIds` (plural). (2) type changed from `number` to `Array<number>`. 
2. _PowerOrders_ and _PowerPlans_ are now linked. That is, both are enabled or disabled together. 
3. _PowerOrders_ and _PowerPlans_ are disabled by default (breaking change).
4. The `enablePowerPlans` property was removed entirely and _PowerPlans_ and _PowerOrders_ are enabled via the use of the `targetTab` of `power orders`  and `power medications` (breaking change).