### PR TITLE
Development

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.7.2-alpha.0",
+  "version": "0.8.0-alpha.0",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/functional/makeCclRequest.ts
+++ b/src/functional/makeCclRequest.ts
@@ -67,6 +67,10 @@ export type CclRequestResponse<T> = {
     responseText: string;
     status: number;
     statusText: XmlCclStatus;
+    statusDetails: string;
+    prgName: string;
+    prgArguments: string;
+    __original: XMLCclRequest;
   };
   data: T | undefined;
 };
@@ -133,6 +137,10 @@ export function makeCclRequest<T>(
             responseText: responseText || 'no response text',
             status: request.status,
             statusText: statusText || 'status refers to unknown error',
+            statusDetails: request.statusText,
+            prgName: request.url,
+            prgArguments: request.requestText,
+            __original: request,
           },
           data,
         };

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,6 +73,10 @@ declare global {
     requestBinding: string;
     requestText: string;
     blobIn: string;
+    url: string;
+    method: string;
+    requestHeaders: Object;
+    requestLen: number;
     onreadystatechange: () => void;
     onerror: () => void;
     abort: () => void;


### PR DESCRIPTION
Enhanced `CclRequestResponse` by adding additional properties that will make debugging errors experienced with _async_ AJAX calls via `makeCclRequest` simpler.

```ts
export type CclRequestResponse<T> = {
  meta: {
    responseText: string;
    status: number;
    statusText: XmlCclStatus;
    statusDetails: string;
    prgName: string;
    prgArguments: string;
    __original: XMLCclRequest;
  };
  data: T | undefined;
};
```