### PR TITLE
implemented task #63 and supported inferred types for makeCclRequests …

### DIFF
--- a/demo.js
+++ b/demo.js
@@ -2,12 +2,8 @@ const {
   orderString,
   submitOrders,
   makeCclRequest,
-  MPageOrder,
-  MPageOrderEvent,
   openPatientTab,
   openOrganizerTab,
-  OrderStrOpts,
-  NewOrderStrOpts,
   launchClinicalNote,
   launchPowerForm,
   launchPowerNote,
@@ -54,6 +50,18 @@ makeCclRequest({
   .then(data => (result = data))
   .catch(console.error)
   .finally(() => console.log(result));
+
+/********************************************************
+ * Alternative example, where the parameter types are inferred
+ ********************************************************/
+let altResult = undefined;
+makeCclRequest({
+  prg: 'MP_GET_ORDER_LIST',
+  params: [12345, 'joe'],
+})
+  .then(data => (altResult = data))
+  .catch(console.error)
+  .finally(() => console.log(altResult));
 
 /********************************************************
  * Open a specific tab in a patients chart

--- a/src/functional/makeCclRequest.spec.ts
+++ b/src/functional/makeCclRequest.spec.ts
@@ -61,4 +61,19 @@ describe('processCclRequestParams', () => {
     const result = processCclRequestParams(params, true);
     expect(result).toEqual("'test'");
   });
+  it('handles properly processes parameters when the list items types are decided without explicit type declaration', () => {
+    const params: Array<number | string | CclCallParam> = [
+      1234,
+      'test',
+      6789,
+      'test2',
+      { param: 'test3', type: 'string' },
+    ];
+    const result = processCclRequestParams(params, true);
+    expect(result).toEqual("1234,'test',6789,'test2','test3'");
+  });
+  it('throws and error when invalid parameters are given', () => {
+    const params: Array<number | string> = [{ test: 'test' } as any];
+    expect(() => processCclRequestParams(params, true)).toThrowError();
+  });
 });


### PR DESCRIPTION
…params

Previously a `makeCclRequest` function call would require a series of parameters with explicit type definitions using a proprietary type called `CclCallParam` with two member properties: 1. `type`, and 2. `param`. This was to allow developers to ensure that the parameter is properly decorated before the parameters string is submit via `XmlCclRequest`.  This is because in some instances one might submit a number as a string, for example. This update implements inferred type support.  Now in the `opts` argument (type `CclOpts`) in `makeCclRequest` has an update to the property `params` such that it is of type `Array<number | string | CclCallParam>`.