### PR TITLE
fixed issue #48 and fixed return type for submitOrders function

### DIFF
--- a/src/functional/submitOrders.ts
+++ b/src/functional/submitOrders.ts
@@ -1,3 +1,4 @@
+import { MPageEventReturn } from '.';
 import {
   outsideOfPowerChartError,
   warnAttemptedOrdersOutsideOfPowerChart,
@@ -59,7 +60,7 @@ export const submitOrders = (
   encounterId: number,
   orders: Array<string>,
   opts?: SubmitOrderOpts
-): { eventString: string; inPowerChart: boolean } => {
+): MPageEventReturn => {
   let { targetTab, launchView, signSilently, dryRun } = opts || {};
   if (!targetTab) targetTab = 'orders';
   if (!launchView) launchView = 'signature';


### PR DESCRIPTION
While the interface matched, the `submitOrders` function was not using the `MPageEventReturn` order type and that was interfering with IDE-related type hinting. The return type was fixed so that now the call signature for `submitOrders` is:

```ts
export const submitOrders = (
  personId: number,
  encounterId: number,
  orders: Array<string>,
  opts?: SubmitOrderOpts
): MPageEventReturn => { // impl }
```