### PR TITLE
Fix to avoid security vulns in dependency fast-xml-parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "fast-xml-parser": "4.2.6"
+        "fast-xml-parser": "4.5.4"
       },
       "devDependencies": {
         "@size-limit/preset-small-lib": "7.0.5",
@@ -6132,19 +6132,16 @@
       "dev": true
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.6.tgz",
-      "integrity": "sha512-Xo1qV++h/Y3Ng8dphjahnYe+rGHaaNdsYOBWL9Y9GCPKpNKilJtilvWkLcI9f9X2DoKTLsZsGYAls5+JL5jfLA==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.4.tgz",
+      "integrity": "sha512-jE8ugADnYOBsu1uaoayVl1tVKAMNOXyjwvv2U6udEA2ORBhDooJDWoGxTkhd4Qn4yh59JVVt/pKXtjPwx9OguQ==",
       "funding": [
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/naturalintelligence"
-        },
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "strnum": "^1.0.5"
       },
@@ -12117,20 +12114,6 @@
         "uglify-js": {
           "optional": true
         }
-      }
-    },
-    "node_modules/terser-webpack-plugin/node_modules/acorn": {
-      "version": "8.11.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
-      "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/terser-webpack-plugin/node_modules/jest-worker": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "typescript": "4.5.4"
   },
   "dependencies": {
-    "fast-xml-parser": "4.2.6"
+    "fast-xml-parser": "4.5.4"
   },
   "peerDependencies": {
     "easy-ccl-request": "^1.0.0"


### PR DESCRIPTION
# Summary
fluent-cerner-js is currently dependent on fast-xml-parser version 4.2.6

## Security Issues
fast-xml-parser <= 4.5.3 has the following security vulnerabilities:

[fast-xml-parser has an entity encoding bypass via regex injection in DOCTYPE entity names](https://github.com/advisories/GHSA-m7jm-9gc2-mpf2) | Critical severity
[fast-xml-parser affected by DoS through entity expansion in DOCTYPE (no expansion limit)](https://github.com/advisories/GHSA-jmr7-xgp7-cmfj) | High severity
[fast-xml-parser has stack overflow in XMLBuilder with preserveOrder](https://github.com/advisories/GHSA-fj3w-jwp8-x2g3) | Low severity

## Actions Taken
- Updated dependency fast-xml-parser to version 4.5.4
- Ran tests (all passed)