### PR TITLE
Changes to openApplicationAsync to allow for better handling of PM Office Conversations

### DIFF
--- a/src/openApplicationAsync.spec.ts
+++ b/src/openApplicationAsync.spec.ts
@@ -75,7 +75,7 @@ describe('generateOpenApplicationArgumentString', () => {
     ];
 
     const argString = generateOpenApplicationArgumentString(args);
-    expect(argString).toBe('/PERSONID=1 /ENCNTRID=123 /FIRSTTAB=^ORDERS^');
+    expect(argString).toBe('/PERSONID=1 /ENCNTRID=123 /FIRSTTAB=^Orders^');
   });
   it('Generates a correct argument string with quick open', () => {
     const args: Array<OpenApplicationArgument> = [
@@ -95,7 +95,7 @@ describe('generateOpenApplicationArgumentString', () => {
     ];
 
     const argString = generateOpenApplicationArgumentString(args);
-    expect(argString).toBe('/PERSONID=1 /ENCNTRID=123 /FIRSTTAB=^ORDERS+^');
+    expect(argString).toBe('/PERSONID=1 /ENCNTRID=123 /FIRSTTAB=^Orders+^');
   });
   it('Tabs string is surrounded by ^', () => {
     const args: Array<OpenApplicationArgument> = [
@@ -106,7 +106,7 @@ describe('generateOpenApplicationArgumentString', () => {
     ];
 
     const argString = generateOpenApplicationArgumentString(args);
-    expect(argString).toBe('/FIRSTTAB=^ORDERS^');
+    expect(argString).toBe('/FIRSTTAB=^Orders^');
   });
   it('Non-tab string is not surrounded by ^', () => {
     const args: Array<OpenApplicationArgument> = [
@@ -117,6 +117,6 @@ describe('generateOpenApplicationArgumentString', () => {
     ];
 
     const argString = generateOpenApplicationArgumentString(args);
-    expect(argString).toBe('/POWERCHART.EXE=RANDOM');
+    expect(argString).toBe('/POWERCHART.EXE=Random');
   });
 });

--- a/src/openApplicationAsync.ts
+++ b/src/openApplicationAsync.ts
@@ -98,10 +98,9 @@ export function generateOpenApplicationArgumentString(
       const quickOpenStr = quickOpen && isTab && !isOrgLevel ? '+' : '';
       const surroundStr = isTab ? '^' : '';
 
-      return `/${arg}=${surroundStr}${value}${quickOpenStr}${surroundStr}`;
+      return `/${arg.toUpperCase()}=${surroundStr}${value}${quickOpenStr}${surroundStr}`;
     })
-    .join(' ')
-    .toUpperCase();
+    .join(' ');
 }
 
 const modeMap = new Map<OpenApplicationMode, 0 | 1 | 100>();

--- a/src/openOrganizerTabAsync.spec.ts
+++ b/src/openOrganizerTabAsync.spec.ts
@@ -13,7 +13,7 @@ describe('openOrganizerTab', () => {
   });
   test('returns an appropriately formatted eventString', async () => {
     const { eventString } = await openOrganizerTabAsync('Tab Name');
-    expect(eventString).toBe(`/ORGANIZERTAB=^TAB NAME^`);
+    expect(eventString).toBe(`/ORGANIZERTAB=^Tab Name^`);
   });
   test('badInput returns false if response is anything other than null', async () => {
     Object.defineProperty(window, 'APPLINK', {

--- a/src/openPatientTabAsync.spec.ts
+++ b/src/openPatientTabAsync.spec.ts
@@ -14,11 +14,11 @@ describe('openPatientTab', () => {
   });
   test('returns an appropriately formatted eventString without quickadd', async () => {
     const { eventString } = await openPatientTabAsync(0, 1, 'Tab Name');
-    expect(eventString).toBe(`/PERSONID=0 /ENCNTRID=1 /FIRSTTAB=^TAB NAME^`);
+    expect(eventString).toBe(`/PERSONID=0 /ENCNTRID=1 /FIRSTTAB=^Tab Name^`);
   });
   test('returns an appropriately formatted eventString with quickadd', async () => {
     const { eventString } = await openPatientTabAsync(0, 1, 'Tab Name', true);
-    expect(eventString).toBe(`/PERSONID=0 /ENCNTRID=1 /FIRSTTAB=^TAB NAME+^`);
+    expect(eventString).toBe(`/PERSONID=0 /ENCNTRID=1 /FIRSTTAB=^Tab Name+^`);
   });
   test('badInput returns false if response is anything other than null', async () => {
     Object.defineProperty(window, 'APPLINK', {


### PR DESCRIPTION
Fix for opening PM Office Conversations using openApplicationAsync. Currently, nothing will happen as a result of the capitalisation behaviour inside `generateOpenApplicationArgumentString`

When calling `APPLINK(<modeValue>, "PMOfficeWrapper.exe", ...)` one of the required params is `/PMFUNCTION=PMActionWrapperRun` and is case-sensitive (for some reason). (See https://community.oracle.com/oraclehealth/discussion/comment/1671663).

Henceforth, an OpenApplicationArgument as follows once parsed through `generateOpenApplicationArgumentString`
```
{
  argument: 'PMFUNCTION',
  value: 'PMActionWrapperRun',
}
```
would be converted to `/PMFUNCTION=PMACTIONWRAPPERRUN` in the returned string, which would fail to open the PM Office Conversation window.

I've corrected this behaviour to only captalise the argument itself, and not the value etc. However, not sure if there is an original reason you implemented it like this. Would not surprise me to learn that values NOT being capitalised breaks something elsewhere! So please do update / review if you'd prefer I modify `openApplicationAsync` to change capitalisation behaviour only where the APPLINK `target` provided is "PMOfficeWrapper.exe"🙂
